### PR TITLE
Add pre-commit to project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+-   repo: https://github.com/golangci/golangci-lint.git
+    rev: v1.55.2
+    hooks:
+    -   id: golangci-lint
+        args: [
+          "run",
+          "--enable-all",
+          "--disable",
+          "lll",
+          "--exclude",
+          "generated/*"
+        ]


### PR DESCRIPTION
We've implemented pre-commit hooks to enhance our development process by ensuring code quality and consistency. 
This pull request includes the configuration for basic pre-commit hooks for our Go project.
The `.pre-commit-config.yaml` file can be extended in the future.

closes #5 