### PR TITLE
Add Integration test for Peer 

### DIFF
--- a/cmd/test/peer_test.go
+++ b/cmd/test/peer_test.go
@@ -1,0 +1,60 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/scherzma/Skunk/cmd/skunk/adapter/in/peer"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPeerSendMessageWorkflow(t *testing.T) {
+	peer1, err := peer.NewPeer("127.0.0.1", "1111", "")
+	if err != nil {
+		t.Errorf("Error creating peer one %v", err)
+	}
+
+	assert.Equal(t, peer1.Hostname, "127.0.0.1")
+	assert.Equal(t, peer1.Port, "1111")
+	assert.Equal(t, peer1.ProxyAddr, "")
+
+	peer2, err := peer.NewPeer("127.0.0.1", "6969", "")
+	if err != nil {
+		t.Errorf("Error creating peer one %v", err)
+	}
+
+	assert.Equal(t, peer2.Hostname, "127.0.0.1")
+	assert.Equal(t, peer2.Port, "6969")
+	assert.Equal(t, peer2.ProxyAddr, "")
+
+	t.Log("Created both peers!")
+
+	peer1.Listen()
+	peer2.Listen()
+
+	t.Log("Both peers are listening")
+
+	err_connect := peer1.Connect(fmt.Sprintf("ws://%s:%s", peer2.Hostname, peer2.Port))
+	if err_connect != nil {
+		t.Errorf("Error connecting to peer two %v", err_connect)
+	}
+
+	err_message := peer1.WriteMessage("Hello Peer Two!")
+	if err_message != nil {
+		t.Errorf("Error sending message to peer two %v", err)
+	}
+
+	v, err := peer2.ReadMessage()
+	if err != nil {
+		t.Errorf("Error reading message peer two %v", err)
+	}
+
+	t.Log("Peer One -> ", v)
+	assert.Equal(t, v.(string), "Hello Peer Two!")
+
+	peer1.Shutdown()
+	peer2.Shutdown()
+
+	t.Log("Both peers are shut down")
+}

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,10 @@ require (
 	golang.org/x/net v0.21.0
 	nhooyr.io/websocket v1.8.10
 )
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,13 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=
 golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 nhooyr.io/websocket v1.8.10 h1:mv4p+MnGrLDcPlBoWsvPP7XCzTYMXP9F9eIGoKbgx7Q=
 nhooyr.io/websocket v1.8.10/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=


### PR DESCRIPTION
This pull request implements one basic integration test for the peer code.
To do this, it was necessary to make the Socks5 proxy "optional" in the peer code so that the peer works completely via the clearnet in the local network. This unit test verifies the functionality of the peer.
To run the test `cd` into the `test/` folder and run 
````go
go test
````

Closes #12